### PR TITLE
sympy no longer included in coverage analysis

### DIFF
--- a/pyth_lang/.coveragerc
+++ b/pyth_lang/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = *sympy*


### PR DESCRIPTION
Currently, running `nosetests --with-coverage --cover-html` performs coverage analysis on all of sympy as well as on Pyth. To disable this behavior, I added a .coveragerc file.
